### PR TITLE
修复：使用远程随机图片API自动切换时出现 "Lock file is already being held" 错误

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "background-cover",
-    "version": "3.1.0",
+    "version": "3.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "background-cover",
-            "version": "3.1.0",
+            "version": "3.2.3",
             "license": "ISC",
             "dependencies": {
                 "async-mutex": "^0.5.0",

--- a/src/FileDom.ts
+++ b/src/FileDom.ts
@@ -392,6 +392,11 @@ export class FileDom {
 
     // 应用补丁
     private async applyPatch(): Promise<boolean> {
+        if (this.initializePromise) {
+            await this.initializePromise;
+            this.initializePromise = undefined;
+        }
+
         const lockPath = path.join(os.tmpdir(), 'vscode-background.lock');
         let release: (() => Promise<void>) | undefined;
 
@@ -409,11 +414,6 @@ export class FileDom {
                 },
                 stale: 20000
             });
-
-            if (this.initializePromise) {
-                await this.initializePromise;
-                this.initializePromise = undefined;
-            }
 
             // Save CSS first
             try {

--- a/src/PickList.ts
+++ b/src/PickList.ts
@@ -75,6 +75,7 @@ enum InputType {
 export class PickList {
     public static itemList: PickList | undefined;
     private static intervalHandle: NodeJS.Timeout | undefined;
+    private static isAutoRunning: boolean = false;
 
     private readonly quickPick: QuickPick<ImgItem> | any;
     private _disposables: Disposable[] = [];
@@ -167,15 +168,25 @@ export class PickList {
 
         if (autoStatus && interval > 0) {
             console.log(`[BackgroundCover] Starting auto update task. Interval: ${interval}s`);
-            PickList.intervalHandle = setInterval(() => {
+            PickList.intervalHandle = setInterval(async () => {
+                if (PickList.isAutoRunning) {
+                    console.log('[BackgroundCover] Previous auto update still running, skipping this round');
+                    return;
+                }
                 const cfg = workspace.getConfiguration('backgroundCover');
                 const context = getContext();
                 const hasOnlineFolder = context.globalState.get('backgroundCoverOnlineFolder');
                 const hasSingleSource = context.globalState.get('backgroundCoverSingleImageSource');
                 if (cfg.randomImageFolder || hasOnlineFolder || hasSingleSource) {
-                    const pl = new PickList(cfg);
-                    // Silent update: no persist, no UI messages
-                    pl.autoUpdateBackground(false).catch(err => console.error(err));
+                    PickList.isAutoRunning = true;
+                    try {
+                        const pl = new PickList(cfg);
+                        await pl.autoUpdateBackground(false);
+                    } catch (err) {
+                        console.error(err);
+                    } finally {
+                        PickList.isAutoRunning = false;
+                    }
                 }
             }, interval * 1000);
         }


### PR DESCRIPTION
问题：
开启自动切换背景并使用 HTTPS 随机图片 API（如 https://api.xxx.com/random）时，运行一段时间后频繁报错：

> Installation failed: Lock file is already being held

一旦触发，必须重启 VSCode 才能恢复。

根因
两个问题叠加导致锁冲突：

1. 自动切换定时器缺少并发保护 — setInterval 每隔 N 秒触发一次，不检查上一轮任务是否执行完毕。当图片下载较慢时，多个任务堆积并争抢同一个文件锁。

2. 图片下载在锁持有期间进行 — applyPatch() 先获取文件锁，再等待图片下载完成（最长 15 秒超时），不必要地长时间占用锁。

随机图片 API 的 URL 通常没有文件扩展名，导致 uniqueDownload = true，每次都会完整下载，无法命中缓存，进一步加剧问题。

修复
1. 添加 isAutoRunning 互斥守卫（PickList.ts）— 如果上一轮自动切换任务仍在执行，跳过本轮，避免并发堆积。

2. 将图片下载移出锁的范围（FileDom.ts）— await initializePromise（图片下载）在获取锁之前完成，锁仅保护快速的本地文件 I/O 操作（毫秒级），不再包含网络下载。