### PR TITLE
适配 Cursor Agent Window（Glass 窗口）背景显示

### DIFF
--- a/src/FileDom.ts
+++ b/src/FileDom.ts
@@ -48,7 +48,10 @@ const WORKBENCH_TARGETS: WorkbenchTarget[] = [
         // background show up there too. Optional: the file is only present in VSCode
         // builds that ship the AgentView; older builds will be skipped at runtime.
         additionalBundles: [
-            { relativePath: path.join('vs', 'sessions', 'sessions.desktop.main.js') }
+            { relativePath: path.join('vs', 'sessions', 'sessions.desktop.main.js') },
+            // Cursor Agent Window (codename "Glass") — same workbench dir but a
+            // separate renderer bundle picked when the window config has glass=true.
+            { relativePath: path.join('vs', 'workbench', 'workbench.glass.main.js') }
         ]
     },
     {

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -17,6 +17,8 @@ const extName = "backgroundCover";
 const TARGET_JS_PATHS: string[] = [
     path.join(base, 'resources', 'app', 'out', 'vs', 'workbench', 'workbench.desktop.main.js'),
     path.join(base, 'resources', 'app', 'out', 'vs', 'sessions', 'sessions.desktop.main.js'),
+    // Cursor Agent Window (Glass) renderer bundle
+    path.join(base, 'resources', 'app', 'out', 'vs', 'workbench', 'workbench.glass.main.js'),
     // code-server (web mode) install layout
     path.join(base, 'resources', 'app', 'out', 'vs', 'code', 'browser', 'workbench', 'workbench.js')
 ];


### PR DESCRIPTION
## 背景

Cursor 更新后新增了独立的 Agent Window（内部代号 Glass）。它和 IDE 主窗口共用同一个启动器（workbench.html / workbench.js），但当窗口配置为 glass 时，实际加载的渲染主包是 `out/vs/workbench/workbench.glass.main.js`，而不是 `workbench.desktop.main.js`。因此现有补丁对 Agent Window 不生效，该窗口内没有背景图。

## 改动

复用现有的 `additionalBundles` 机制（即之前为 VSCode AgentView 的 `sessions.desktop.main.js` 引入的那套附加 bundle 逻辑）：

- `src/FileDom.ts`：desktop 目标的 `additionalBundles` 中加入 `vs/workbench/workbench.glass.main.js`，备份 / 打补丁 / 卸载还原全部自动复用现有流程
- `src/uninstall.ts`：卸载清理列表同步加入该路径

文件不存在时自动跳过，因此对纯 VSCode / code-server 用户零影响。

## 实测

Windows 11 + Cursor（2026-07 版本）实测：补丁应用后重启 Agent Window，背景正常显示，透明度 / 模糊 / 自动换图等行为与主窗口一致。