### PR TITLE
feat: 自动换图失败后静默重试，避免弹错并清掉在线源

### DIFF
--- a/src/FileDom.ts
+++ b/src/FileDom.ts
@@ -14,6 +14,19 @@ import { getContext } from './global';
 import { getParticleEffectJs } from './ParticleEffect';
 import { getAllPets } from './PickList';
 import Color from './color';
+import {
+    BackgroundApplyCancelledError,
+    BackgroundDownloadError,
+    BackgroundPatchError,
+    wrapDownloadError
+} from './downloadError';
+
+export {
+    BackgroundApplyCancelledError,
+    BackgroundDownloadError,
+    BackgroundPatchError,
+    shouldTryNextAutoImage
+} from './downloadError';
 
 interface AdditionalBundle {
     // Path relative to env.appRoot/out, e.g. 'vs/sessions/sessions.desktop.main.js'.
@@ -143,6 +156,12 @@ const HTML_CACHE_BUST_PARAM = 'background-cover';
 const BOOTSTRAP_VERSION = '1';
 const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36';
 const DEFAULT_ACCEPT_HEADER = 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8';
+const DOWNLOAD_MAX_ATTEMPTS = 3;
+const DOWNLOAD_RETRY_DELAYS_MS = [0, 500, 1500];
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 function getWebRelativePath(filePath: string): string | undefined {
     try {
@@ -175,6 +194,7 @@ export class FileDom {
     private readonly forceHttpsUpgrade: boolean;
     private readonly skipOnlineCache: boolean;
     private readonly shouldApply: () => boolean;
+    private readonly silent: boolean;
     private upCssContent: string = '';
     private bakStatus: boolean = false;
     private bakJsContent: string = '';
@@ -192,7 +212,8 @@ export class FileDom {
         blur: number = 0,
         blendModel: string = '',
         skipOnlineCache: boolean = false,
-        shouldApply: () => boolean = () => true
+        shouldApply: () => boolean = () => true,
+        silent: boolean = false
     ) {
         this.workConfig = workConfig;
         this.filePath = JS_FILE_PATH;
@@ -205,6 +226,7 @@ export class FileDom {
         this.forceHttpsUpgrade = this.workConfig.get('forceHttpsUpgrade', true);
         this.skipOnlineCache = skipOnlineCache;
         this.shouldApply = shouldApply;
+        this.silent = silent;
         
         this.initializePromise = this.initializeImage().catch((error: unknown) => {
             console.error('[FileDom] Failed to preprocess image:', error);
@@ -293,33 +315,67 @@ export class FileDom {
                 return;
             }
 
-            const timestamp = Date.now();
-            const tempPath = path.join(cacheDir, `${urlHash}-${timestamp}${ext}.tmp`);
-
-            try {
-                const { contentType } = await this.downloadFile(this.imagePath, tempPath);
-                let finalExt = ext;
-                if ((!ext || ext === '.img' || uniqueDownload) && contentType) {
-                    finalExt = this.getExtensionFromContentType(contentType) || finalExt;
+            let lastError: BackgroundDownloadError | undefined;
+            for (let attempt = 0; attempt < DOWNLOAD_MAX_ATTEMPTS; attempt++) {
+                if (!this.shouldApply()) {
+                    throw new BackgroundApplyCancelledError();
+                }
+                if (attempt > 0) {
+                    if (!lastError || !lastError.retrySame) {
+                        break;
+                    }
+                    const waitMs = DOWNLOAD_RETRY_DELAYS_MS[attempt] || 1500;
+                    console.warn(`[FileDom] Retrying download (${attempt + 1}/${DOWNLOAD_MAX_ATTEMPTS}) in ${waitMs}ms:`, lastError.message);
+                    await delay(waitMs);
+                    if (!this.shouldApply()) {
+                        throw new BackgroundApplyCancelledError();
+                    }
                 }
 
-                const targetPath = (!uniqueDownload && isStaticImage)
-                    ? cachePath
-                    : path.join(cacheDir, `${urlHash}-${timestamp}${finalExt || '.img'}`);
+                const timestamp = Date.now();
+                const tempPath = path.join(cacheDir, `${urlHash}-${timestamp}-${attempt}${ext}.tmp`);
+                try {
+                    const { contentType } = await this.downloadFile(this.imagePath, tempPath);
+                    let finalExt = ext;
+                    if ((!ext || ext === '.img' || uniqueDownload) && contentType) {
+                        finalExt = this.getExtensionFromContentType(contentType) || finalExt;
+                    }
 
-                await fse.move(tempPath, targetPath, { overwrite: true });
-                this.imagePath = targetPath;
-            } catch (error) {
-                if (await fse.pathExists(cachePath)) {
-                    this.imagePath = cachePath;
-                    console.warn('[FileDom] Download failed, using cached image:', error);
-                } else {
-                    throw error;
+                    const targetPath = (!uniqueDownload && isStaticImage)
+                        ? cachePath
+                        : path.join(cacheDir, `${urlHash}-${timestamp}${finalExt || '.img'}`);
+
+                    await fse.move(tempPath, targetPath, { overwrite: true });
+                    this.imagePath = targetPath;
+                    return;
+                } catch (error) {
+                    lastError = wrapDownloadError(error);
+                    try {
+                        if (await fse.pathExists(tempPath)) {
+                            await fse.unlink(tempPath);
+                        }
+                    } catch {
+                        // ignore temp cleanup
+                    }
+                    if (!lastError.retrySame) {
+                        break;
+                    }
                 }
             }
+
+            if (await fse.pathExists(cachePath)) {
+                this.imagePath = cachePath;
+                console.warn('[FileDom] Download failed, using cached image:', lastError);
+                return;
+            }
+            throw lastError || new BackgroundDownloadError('Failed to download image');
         } catch (error) {
-            console.error('[FileDom] Failed to download image:', error);
-            throw error;
+            if (error instanceof BackgroundApplyCancelledError) {
+                throw error;
+            }
+            const downloadError = wrapDownloadError(error);
+            console.error('[FileDom] Failed to download image:', downloadError);
+            throw downloadError;
         }
     }
 
@@ -330,7 +386,7 @@ export class FileDom {
             try {
                 urlObj = new URL(url);
             } catch (error) {
-                reject(error);
+                reject(wrapDownloadError(error));
                 return;
             }
 
@@ -340,6 +396,10 @@ export class FileDom {
                 'Referer': `${urlObj.protocol}//${urlObj.host}/`,
             } as Record<string, string>;
 
+            const fail = (error: unknown, statusCode?: number) => {
+                reject(wrapDownloadError(error, statusCode));
+            };
+
             const protocolHandler = urlObj.protocol === 'https:' ? https : http;
             const request = protocolHandler.request(urlObj, { method: 'GET', headers }, (response) => {
                 const statusCode = response.statusCode ?? 0;
@@ -348,12 +408,12 @@ export class FileDom {
                     const location = response.headers.location;
                     if (!location) {
                         response.resume();
-                        reject(new Error(`Failed to download: ${statusCode}`));
+                        fail(new Error(`Failed to download: ${statusCode}`), statusCode);
                         return;
                     }
                     if (redirectCount > 5) {
                         response.resume();
-                        reject(new Error('Too many redirects'));
+                        fail(new Error('Too many redirects'));
                         return;
                     }
                     const nextUrl = new URL(location, urlObj).toString();
@@ -364,7 +424,7 @@ export class FileDom {
 
                 if (statusCode !== 200) {
                     response.resume();
-                    reject(new Error(`Failed to download: ${statusCode}`));
+                    fail(new Error(`Failed to download: ${statusCode}`), statusCode);
                     return;
                 }
 
@@ -375,7 +435,7 @@ export class FileDom {
                     resolve({ contentType: response.headers['content-type'] as string | undefined });
                 });
                 file.on('error', (err) => {
-                    fs.unlink(dest, () => reject(err));
+                    fs.unlink(dest, () => fail(err));
                 });
             });
 
@@ -384,7 +444,7 @@ export class FileDom {
             });
 
             request.on('error', (err) => {
-                reject(err);
+                fail(err);
             });
 
             request.setTimeout(15000);
@@ -395,6 +455,9 @@ export class FileDom {
     //应用补丁安装
     public async install(): Promise<boolean> {
         if (!(await this.checkFileExists())) {
+            if (this.silent) {
+                throw new BackgroundPatchError('Workbench file is missing');
+            }
             return false;
         }
 
@@ -440,19 +503,16 @@ export class FileDom {
 
     // 应用补丁
     private async applyPatch(): Promise<boolean> {
-        if (this.initializePromise) {
-            await this.initializePromise;
-            this.initializePromise = undefined;
-        }
-
-        if (!this.shouldApply()) {
-            return false;
-        }
-
         const lockPath = path.join(os.tmpdir(), 'vscode-background.lock');
         let release: (() => Promise<void>) | undefined;
 
         try {
+            await this.ensureInitialized();
+
+            if (!this.shouldApply()) {
+                throw new BackgroundApplyCancelledError();
+            }
+
             if (!(await fse.pathExists(lockPath))) {
                 await fse.writeFile(lockPath, '', 'utf-8');
             }
@@ -468,7 +528,7 @@ export class FileDom {
             });
 
             if (!this.shouldApply()) {
-                return false;
+                throw new BackgroundApplyCancelledError();
             }
 
             // Save dynamic assets first. The patched workbench bundle only keeps a
@@ -478,18 +538,31 @@ export class FileDom {
                 this.didUpdateDynamicJs = await this.saveDynamicJsContent();
             } catch (e) {
                 window.showErrorMessage('Failed to write background assets: ' + e);
+                if (this.silent) {
+                    throw new BackgroundPatchError(String(e));
+                }
                 return false;
             }
 
             const content = this.getJs().trim();
-            if (!content) return false;
+            if (!content) {
+                if (this.silent) {
+                    throw new BackgroundPatchError('Generated patch content is empty');
+                }
+                return false;
+            }
 
             const patchHash = crypto.createHash('md5').update(content).digest('hex').slice(0, 8);
 
             // Patch main workbench bundle. captureBak: true means if no backup exists
             // yet we save the pre-patch content for safety.
             const mainResult = await this.patchOneJsFile(this.filePath, BAK_FILE_PATH, content, true);
-            if (mainResult === 'failed') return false;
+            if (mainResult === 'failed') {
+                if (this.silent) {
+                    throw new BackgroundPatchError('Failed to patch workbench file');
+                }
+                return false;
+            }
 
             // Patch any additional bundles (AgentView etc). Skipping ones that don't
             // exist keeps us forward/backward compatible across VSCode versions.
@@ -513,7 +586,13 @@ export class FileDom {
             return true;
 
         } catch (error: any) {
+            if (error instanceof BackgroundApplyCancelledError || error instanceof BackgroundDownloadError) {
+                throw error;
+            }
             await this.handlePatchError(error);
+            if (this.silent) {
+                throw new BackgroundPatchError((error && (error.message || error.toString())) || 'Failed to install background patch');
+            }
             return false;
         } finally {
             if (release) {
@@ -523,6 +602,24 @@ export class FileDom {
                     console.error(`Failed to unlock ${lockPath}:`, err);
                 }
             }
+        }
+    }
+
+    private async ensureInitialized(): Promise<void> {
+        if (!this.initializePromise) {
+            return;
+        }
+        const pending = this.initializePromise;
+        try {
+            await pending;
+            if (this.initializePromise === pending) {
+                this.initializePromise = undefined;
+            }
+        } catch (error) {
+            if (this.initializePromise === pending) {
+                this.initializePromise = undefined;
+            }
+            throw error;
         }
     }
 
@@ -565,7 +662,12 @@ export class FileDom {
         if (!choice) { return; }
         if (choice === 'Retry / 重试') {
             // Re-attempt without recursion blowing the stack; small delay so any
-            // transient lock has a chance to clear.
+            // transient lock has a chance to clear. Restart image preprocessing
+            // so a previous failed download is not reused.
+            this.initializePromise = this.initializeImage().catch((error: unknown) => {
+                console.error('[FileDom] Failed to preprocess image:', error);
+                throw error;
+            });
             setTimeout(() => { void this.applyPatch(); }, 300);
             return;
         }

--- a/src/PickList.ts
+++ b/src/PickList.ts
@@ -19,6 +19,7 @@ import {
 } from 'vscode';
 
 import { FileDom } from './FileDom';
+import { BackgroundPatchError, BackgroundApplyCancelledError, shouldTryNextAutoImage, pickUnusedCandidate } from './downloadError';
 import { ImgItem } from './ImgItem';
 import vsHelp from './vsHelp';
 import { getContext, onDidChangeGlobalState } from './global';
@@ -86,6 +87,13 @@ export interface PetEntry {
 
 interface UpdateBackgroundOptions {
     skipLargeImagePrompt?: boolean;
+}
+
+const AUTO_IMAGE_ATTEMPTS = 3;
+const ONLINE_LIST_FETCH_ATTEMPTS = 2;
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 /** Single source of truth for available pets (used by PickList + FileDom + Studio webview). */
@@ -187,6 +195,7 @@ export class PickList {
     private blur: number;
     private randUpdate: boolean = false;
     private skipOnlineCache: boolean = false;
+    private silentApply: boolean = false;
 
     // --- Static Entry Points ---
 
@@ -639,6 +648,7 @@ export class PickList {
     }
 
     private async autoUpdateBackground(persist: boolean = true): Promise<boolean> {
+        this.silentApply = !persist;
         const context = getContext();
         const onlineFolder = context.globalState.get<string>('backgroundCoverOnlineFolder');
         const cachedImages = context.globalState.get<string[]>('backgroundCoverOnlineImageList');
@@ -647,42 +657,95 @@ export class PickList {
             try {
                 let images = cachedImages as string[] | undefined;
                 if (!images || images.length === 0) {
-                    if (persist) {
-                        window.showInformationMessage('正在从在线文件夹获取图片列表...');
-                    }
-                    images = await OnlineImageHelper.getOnlineImages(onlineFolder);
-                    context.globalState.update('backgroundCoverOnlineImageList', images);
+                    images = await this.fetchOnlineImageList(onlineFolder, persist);
                 }
                 if (images && images.length > 0) {
+                    if (!persist) {
+                        return await this.applyAutoCandidates(images, persist);
+                    }
                     const randomImage = images[Math.floor(Math.random() * images.length)];
                     await this.updateBackgound(randomImage, false, persist, { skipLargeImagePrompt: true });
                     return true;
                 }
             } catch (error: any) {
                 console.error('从在线文件夹获取图片失败:', error);
+                if (error instanceof BackgroundApplyCancelledError || error instanceof BackgroundPatchError) {
+                    return false;
+                }
                 if (persist) {
                     window.showWarningMessage('在线文件夹访问失败，请检查网络连接！');
                 }
-                this.clearOnlineFolder(true);
             }
         }
 
         const singleSource = context.globalState.get<string>('backgroundCoverSingleImageSource');
         if (singleSource && this.isOnlineUrl(singleSource)) {
+            if (!persist) {
+                return await this.applyAutoCandidates([singleSource], persist);
+            }
             await this.updateBackgound(singleSource, false, persist, { skipLargeImagePrompt: true });
             return true;
         }
 
         const randomImageFolder = this.config.get<string>('randomImageFolder');
         if (randomImageFolder && this.checkFolder(randomImageFolder)) {
-            const files = this.getFolderImgList(randomImageFolder);
+            const files = this.getFolderImgList(randomImageFolder).map(file => path.join(randomImageFolder, file));
             if (files.length > 0) {
+                if (!persist) {
+                    return await this.applyAutoCandidates(files, persist);
+                }
                 const randomFile = files[Math.floor(Math.random() * files.length)];
-                const file = path.join(randomImageFolder, randomFile);
-                await this.updateBackgound(file, false, persist, { skipLargeImagePrompt: true });
+                await this.updateBackgound(randomFile, false, persist, { skipLargeImagePrompt: true });
             }
         }
         return true;
+    }
+
+    private async fetchOnlineImageList(onlineFolder: string, persist: boolean): Promise<string[] | undefined> {
+        const attempts = persist ? 1 : ONLINE_LIST_FETCH_ATTEMPTS;
+        for (let i = 0; i < attempts; i++) {
+            if (i > 0) {
+                await delay(500);
+            }
+            if (persist && i === 0) {
+                window.showInformationMessage('正在从在线文件夹获取图片列表...');
+            }
+            try {
+                const images = await OnlineImageHelper.getOnlineImages(onlineFolder);
+                if (images && images.length > 0) {
+                    getContext().globalState.update('backgroundCoverOnlineImageList', images);
+                    return images;
+                }
+            } catch (error) {
+                console.error('[BackgroundCover] Failed to fetch online image list:', error);
+            }
+        }
+        return undefined;
+    }
+
+    private async applyAutoCandidates(candidates: string[], persist: boolean): Promise<boolean> {
+        const tried = new Set<string>();
+        for (let i = 0; i < AUTO_IMAGE_ATTEMPTS; i++) {
+            const next = pickUnusedCandidate(candidates, tried);
+            if (!next) {
+                break;
+            }
+            tried.add(next);
+            try {
+                await this.updateBackgound(next, false, persist, { skipLargeImagePrompt: true });
+                return true;
+            } catch (error) {
+                if (error instanceof BackgroundApplyCancelledError || error instanceof BackgroundPatchError) {
+                    return false;
+                }
+                console.error('[BackgroundCover] Auto image update failed:', error);
+                if (!shouldTryNextAutoImage(error)) {
+                    return false;
+                }
+            }
+        }
+        window.setStatusBarMessage('自动换图失败，将在下个间隔再试 / Auto background update failed, will retry next interval.', 5000);
+        return false;
     }
 
     private openCacheFolder() {
@@ -1414,7 +1477,7 @@ export class PickList {
 
         const seq = ++PickList._updateSeq;
         const isCurrentUpdate = () => seq === PickList._updateSeq;
-        const dom = new FileDom(this.config, this.imgPath, this.opacity, this.sizeModel, this.blur, colorThemeKind, this.skipOnlineCache, isCurrentUpdate);
+        const dom = new FileDom(this.config, this.imgPath, this.opacity, this.sizeModel, this.blur, colorThemeKind, this.skipOnlineCache, isCurrentUpdate, this.silentApply);
         let result = false;
 
         try {
@@ -1483,6 +1546,9 @@ export class PickList {
                 }
             }
         } catch (error: any) {
+            if (this.silentApply) {
+                throw error;
+            }
             await window.showErrorMessage(`更新失败: ${error.message}`);
         }
         return result && (dom.requiresReload || uninstall);

--- a/src/downloadError.ts
+++ b/src/downloadError.ts
@@ -1,0 +1,77 @@
+const RETRYABLE_DOWNLOAD_CODES = new Set([
+    'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN',
+    'ENETUNREACH', 'EHOSTUNREACH', 'EPIPE', 'ECONNABORTED',
+    'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_SOCKET'
+]);
+
+export class BackgroundDownloadError extends Error {
+    readonly statusCode?: number;
+    readonly retrySame: boolean;
+    readonly tryNextImage: boolean = true;
+    readonly code?: string;
+
+    constructor(message: string, options: { statusCode?: number; code?: string } = {}) {
+        super(message);
+        this.name = 'BackgroundDownloadError';
+        this.statusCode = options.statusCode;
+        this.code = options.code;
+        this.retrySame = isRetryableDownload(options.statusCode, message, options.code);
+    }
+}
+
+export class BackgroundPatchError extends Error {
+    readonly tryNextImage: boolean = false;
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'BackgroundPatchError';
+    }
+}
+
+export class BackgroundApplyCancelledError extends Error {
+    readonly tryNextImage: boolean = false;
+
+    constructor() {
+        super('Background apply cancelled');
+        this.name = 'BackgroundApplyCancelledError';
+    }
+}
+
+export function shouldTryNextAutoImage(error: unknown): boolean {
+    return error instanceof BackgroundDownloadError;
+}
+
+export function pickUnusedCandidate(candidates: string[], tried: Set<string>): string | undefined {
+    const pool = candidates.filter(item => !tried.has(item));
+    if (pool.length === 0) {
+        return undefined;
+    }
+    return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function isRetryableDownload(statusCode: number | undefined, message: string, code?: string): boolean {
+    if (statusCode === 429 || (statusCode !== undefined && statusCode >= 500 && statusCode <= 599)) {
+        return true;
+    }
+    if (code && RETRYABLE_DOWNLOAD_CODES.has(code)) {
+        return true;
+    }
+    const lower = message.toLowerCase();
+    return lower.includes('timeout') || lower.includes('socket hang up');
+}
+
+export function wrapDownloadError(error: unknown, statusCode?: number): BackgroundDownloadError {
+    if (error instanceof BackgroundDownloadError) {
+        return error;
+    }
+    const err = error as NodeJS.ErrnoException;
+    const message = (err && err.message) ? err.message : String(error);
+    const code = typeof err?.code === 'string' ? err.code : undefined;
+    const matchedStatus = statusCode ?? parseDownloadStatusCode(message);
+    return new BackgroundDownloadError(message, { statusCode: matchedStatus, code });
+}
+
+function parseDownloadStatusCode(message: string): number | undefined {
+    const match = /Failed to download: (\d+)/.exec(message);
+    return match ? Number(match[1]) : undefined;
+}


### PR DESCRIPTION
## Summary
- 自动换图遇到超时 / 5xx / 连接抖动时，同一张图会短间隔再下最多 2 次；401/403/404 则换列表里的下一张（一轮最多 3 张）。
- 自动换图失败不再弹出「更新失败」，也不再 `clearOnlineFolder`；状态栏提示后等下一个间隔继续。
- 权限不足、文件锁、核心文件缺失仍走原来的人工处理；手动换图和手动刷新在线文件夹行为不变。

## Test plan
- [x] 在线列表中某张图 404：不弹框，自动换另一张，自动换图开关仍开着，在线文件夹配置还在。
- [x] 下载超时或短暂断网：同一张会再试，成功则换上；一直失败只状态栏提示，下个间隔继续。
- [x] 拉在线列表失败：已有列表继续用来换图，不会清掉在线源。
- [x] 权限不足写核心文件：仍弹出原来的人工处理，不会后台死循环。
- [x] 手动刷新在线文件夹失败：仍是原来的错误提示。
- [x] 自动换图过程中手动换图：后台重试停掉，听手动的。