### PR TITLE
feat: 多主窗口各自显示背景，换图不再把其他窗口刷成同一张

### DIFF
--- a/src/FileDom.ts
+++ b/src/FileDom.ts
@@ -14,6 +14,7 @@ import { getContext } from './global';
 import { getParticleEffectJs } from './ParticleEffect';
 import { getAllPets } from './PickList';
 import Color from './color';
+import { getSessionHash, getWindowCssFileName } from './windowBackground';
 
 interface AdditionalBundle {
     // Path relative to env.appRoot/out, e.g. 'vs/sessions/sessions.desktop.main.js'.
@@ -122,7 +123,8 @@ const HTML_FILE_PATH = selectedWorkbench.html ? path.join(selectedWorkbench.root
 const CUSTOM_CSS_FILE_NAME = 'css-background-cover.css';
 const CUSTOM_JS_FILE_NAME = 'js-background-cover.js';
 export const CUSTOM_CSS_FILE_PATH = path.join(selectedWorkbench.root, CUSTOM_CSS_FILE_NAME);
-const CUSTOM_JS_FILE_PATH = path.join(selectedWorkbench.root, CUSTOM_JS_FILE_NAME);
+export const WORKBENCH_DIR = selectedWorkbench.root;
+export const CUSTOM_JS_FILE_PATH = path.join(selectedWorkbench.root, CUSTOM_JS_FILE_NAME);
 const APP_OUT_PATH = path.join(env.appRoot, 'out');
 // Each entry is an additional bundle that needs the same loader IIFE injected
 // (e.g. sessions.desktop.main.js for the AgentView window). Bak path mirrors
@@ -163,6 +165,99 @@ enum SystemType {
     LINUX = 'Linux'
 }
 
+// One elevated grant per directory per process. New per-window CSS files keep
+// appearing under workbench/, so unlocking the folder once avoids a UAC prompt
+// on every new window.
+const dirUnlockInFlight = new Map<string, Promise<void>>();
+
+function quoteWinPath(filePath: string): string {
+    return `"${filePath}"`;
+}
+
+async function unlockDir(dirPath: string): Promise<void> {
+    window.setStatusBarMessage(
+        '正在开放背景文件目录写入权限，请在弹出的授权窗口中确认一次。 / Granting write access to the background folder. Please confirm the permission prompt once.',
+        15000
+    );
+    const systemType = os.type();
+    if (systemType === SystemType.WINDOWS) {
+        const quoted = quoteWinPath(dirPath);
+        // (OI)(CI) = new files and subfolders inherit Users:F, so later windows
+        // can create css-background-cover.<session>.css without another prompt.
+        await SudoPromptHelper.exec(
+            `takeown /f ${quoted} /a & icacls ${quoted} /grant "Users:(OI)(CI)F"`
+        );
+        return;
+    }
+    if (systemType === SystemType.MACOS || systemType === SystemType.LINUX) {
+        await SudoPromptHelper.exec(`chmod a+rwx ${quoteWinPath(dirPath)}`);
+    }
+}
+
+async function ensureDirWritable(dirPath: string): Promise<void> {
+    const normalized = path.normalize(dirPath);
+    const existing = dirUnlockInFlight.get(normalized);
+    if (existing) {
+        await existing;
+        return;
+    }
+    const task = unlockDir(normalized).catch((error) => {
+        dirUnlockInFlight.delete(normalized);
+        throw error;
+    });
+    dirUnlockInFlight.set(normalized, task);
+    await task;
+}
+
+function isElevationCancelled(error: unknown): boolean {
+    return /did not grant permission|canceled|cancelled/i.test(String(error));
+}
+
+export async function removeBackgroundCoverCssFiles(): Promise<void> {
+    if (!(await fse.pathExists(WORKBENCH_DIR))) {
+        return;
+    }
+    let names: string[] = [];
+    try {
+        names = await fse.readdir(WORKBENCH_DIR);
+    } catch (error) {
+        console.warn('[FileDom] Failed to list workbench CSS files:', error);
+        return;
+    }
+    const cssFiles = names.filter(name => name.startsWith('css-background-cover') && name.endsWith('.css'));
+    const systemType = os.type();
+    let dirUnlocked = false;
+    for (const name of cssFiles) {
+        const filePath = path.join(WORKBENCH_DIR, name);
+        try {
+            await fse.remove(filePath);
+            continue;
+        } catch {
+            if (!dirUnlocked) {
+                try {
+                    await ensureDirWritable(WORKBENCH_DIR);
+                    dirUnlocked = true;
+                    await fse.remove(filePath);
+                    continue;
+                } catch (error) {
+                    if (isElevationCancelled(error)) {
+                        throw error;
+                    }
+                }
+            }
+        }
+        try {
+            if (systemType === SystemType.WINDOWS) {
+                await SudoPromptHelper.exec(`del ${quoteWinPath(filePath)}`);
+            } else {
+                await SudoPromptHelper.exec(`rm ${quoteWinPath(filePath)}`);
+            }
+        } catch (error) {
+            console.warn(`[FileDom] Failed to remove ${filePath}:`, error);
+        }
+    }
+}
+
 export class FileDom {
     private readonly filePath: string;
     private readonly extName = "backgroundCover";
@@ -175,6 +270,8 @@ export class FileDom {
     private readonly forceHttpsUpgrade: boolean;
     private readonly skipOnlineCache: boolean;
     private readonly shouldApply: () => boolean;
+    private readonly windowCssFilePath: string;
+    public readonly windowCssToken: string;
     private upCssContent: string = '';
     private bakStatus: boolean = false;
     private bakJsContent: string = '';
@@ -205,6 +302,8 @@ export class FileDom {
         this.forceHttpsUpgrade = this.workConfig.get('forceHttpsUpgrade', true);
         this.skipOnlineCache = skipOnlineCache;
         this.shouldApply = shouldApply;
+        this.windowCssToken = getSessionHash();
+        this.windowCssFilePath = path.join(selectedWorkbench.root, getWindowCssFileName());
         
         this.initializePromise = this.initializeImage().catch((error: unknown) => {
             console.error('[FileDom] Failed to preprocess image:', error);
@@ -660,27 +759,23 @@ export class FileDom {
         }
     }
 
-    // 获取文件权限
+    // 获取单个文件权限（目录授权仍盖不住的已有受保护文件才走这里）
     public async getFilePermission(filePath: string): Promise<void> {
         try {
-            if (!(await fse.pathExists(filePath))) {
-                if (this.systemType === SystemType.WINDOWS) {
-                    await SudoPromptHelper.exec(`echo. > "${filePath}"`);
-                } else {
-                    await SudoPromptHelper.exec(`touch "${filePath}"`);
-                }
+            const quoted = quoteWinPath(filePath);
+            const exists = await fse.pathExists(filePath);
+            if (this.systemType === SystemType.WINDOWS) {
+                const create = exists ? '' : `echo. > ${quoted} & `;
+                await SudoPromptHelper.exec(
+                    `${create}takeown /f ${quoted} /a & icacls ${quoted} /grant Users:F`
+                );
+                return;
             }
-            switch (this.systemType) {
-                case SystemType.WINDOWS:
-                    await SudoPromptHelper.exec(`takeown /f "${filePath}" /a`);
-                    await SudoPromptHelper.exec(`icacls "${filePath}" /grant Users:F`);
-                    break;
-                case SystemType.MACOS:
-                    await SudoPromptHelper.exec(`chmod a+rwx "${filePath}"`);
-                    break;
-                case SystemType.LINUX:
-                    await SudoPromptHelper.exec(`chmod 666 "${filePath}"`);
-                    break;
+            const chmodCmd = this.systemType === SystemType.MACOS ? 'chmod a+rwx' : 'chmod 666';
+            if (exists) {
+                await SudoPromptHelper.exec(`${chmodCmd} ${quoted}`);
+            } else {
+                await SudoPromptHelper.exec(`touch ${quoted} && ${chmodCmd} ${quoted}`);
             }
         } catch (error) {
             console.error(`Failed to get permission for ${filePath}:`, error);
@@ -710,18 +805,8 @@ export class FileDom {
                 }
             }
 
-            // Remove CSS file
-            if (await fse.pathExists(CUSTOM_CSS_FILE_PATH)) {
-                try {
-                    await fse.remove(CUSTOM_CSS_FILE_PATH);
-                } catch {
-                    if (this.systemType === SystemType.WINDOWS) {
-                        await SudoPromptHelper.exec(`del "${CUSTOM_CSS_FILE_PATH}"`);
-                    } else {
-                        await SudoPromptHelper.exec(`rm "${CUSTOM_CSS_FILE_PATH}"`);
-                    }
-                }
-            }
+            // Remove CSS files (shared fallback + per-window copies)
+            await removeBackgroundCoverCssFiles();
 
             if (await fse.pathExists(CUSTOM_JS_FILE_PATH)) {
                 try {
@@ -747,7 +832,7 @@ export class FileDom {
     // 清除背景
     public async clearBackground(): Promise<boolean> {
         try {
-            await this.writeWithPermission(CUSTOM_CSS_FILE_PATH, '');
+            await this.writeWithPermission(this.windowCssFilePath, '');
             this.requiresReload = false;
             return true;
         } catch (error) {
@@ -781,32 +866,28 @@ export class FileDom {
     private async writeWithPermission(filePath: string, content: string): Promise<void> {
         try {
             await fse.writeFile(filePath, content, { encoding: 'utf-8' });
-        } catch (err) {
-            await this.getFilePermission(filePath);
-            await fse.writeFile(filePath, content, { encoding: 'utf-8' });
+            return;
+        } catch {
+            // Install dir is protected; unlock the folder first.
         }
+        try {
+            await ensureDirWritable(path.dirname(filePath));
+            await fse.writeFile(filePath, content, { encoding: 'utf-8' });
+            return;
+        } catch (error) {
+            if (isElevationCancelled(error)) {
+                throw error;
+            }
+            // Existing files (workbench js) can keep a restrictive ACL after the
+            // directory grant. Unlock that one file and retry.
+        }
+        await this.getFilePermission(filePath);
+        await fse.writeFile(filePath, content, { encoding: 'utf-8' });
     }
 
     // 写入备份文件
     private async bakFile(): Promise<void> {
-        try {
-            await fse.writeFile(BAK_FILE_PATH, this.bakJsContent, { encoding: 'utf-8' });
-        } catch (err) {
-            await this.createAndWriteBakFile();
-        }
-    }
-
-    // 创建并写入备份文件
-    private async createAndWriteBakFile(): Promise<void> {
-        if (this.systemType === SystemType.WINDOWS) {
-            await SudoPromptHelper.exec(`echo. > "${BAK_FILE_PATH}"`);
-            await SudoPromptHelper.exec(`icacls "${BAK_FILE_PATH}" /grant Users:F`);
-        } else {
-            await SudoPromptHelper.exec(`touch "${BAK_FILE_PATH}"`);
-            const chmodCmd = this.systemType === SystemType.MACOS ? 'chmod a+rwx' : 'chmod 666';
-            await SudoPromptHelper.exec(`${chmodCmd} "${BAK_FILE_PATH}"`);
-        }
-        await fse.writeFile(BAK_FILE_PATH, this.bakJsContent, { encoding: 'utf-8' });
+        await this.writeWithPermission(BAK_FILE_PATH, this.bakJsContent);
     }
 
     public requiresReload: boolean = true;
@@ -814,18 +895,30 @@ export class FileDom {
     // 写入css内容
     private async saveCssContent(): Promise<boolean> {
         const css = this.getCss();
+        let changed = true;
         try {
-            if (await fse.pathExists(CUSTOM_CSS_FILE_PATH)) {
-                const current = await fse.readFile(CUSTOM_CSS_FILE_PATH, 'utf-8');
+            if (await fse.pathExists(this.windowCssFilePath)) {
+                const current = await fse.readFile(this.windowCssFilePath, 'utf-8');
                 if (current === css) {
-                    return false;
+                    changed = false;
                 }
             }
         } catch {
             // Fall through to write; permission handling below will surface real failures.
         }
-        await this.writeWithPermission(CUSTOM_CSS_FILE_PATH, css);
-        return true;
+        if (changed) {
+            await this.writeWithPermission(this.windowCssFilePath, css);
+        }
+        // Shared file is only a pre-handshake fallback. Seed it when missing so a
+        // brand-new window has something to show before this session's trigger.
+        try {
+            if (!(await fse.pathExists(CUSTOM_CSS_FILE_PATH))) {
+                await this.writeWithPermission(CUSTOM_CSS_FILE_PATH, css);
+            }
+        } catch (error) {
+            console.warn('[FileDom] Failed to seed shared CSS fallback:', error);
+        }
+        return changed;
     }
 
     private async saveDynamicJsContent(): Promise<boolean> {
@@ -1545,6 +1638,19 @@ export class FileDom {
             };
             const cssUrl = resolveCssUrl();
             const cssBaseHref = getCssBaseHref(cssUrl);
+
+            function cssUrlForToken(token) {
+                if (!token) return cssUrl;
+                const windowFile = cssFileName.replace(/\\.css$/, '.' + token + '.css');
+                if (cssUrl.indexOf(cssFileName) !== -1) {
+                    return cssUrl.split(cssFileName).join(windowFile);
+                }
+                return cssUrl;
+            }
+
+            function activeCssUrl() {
+                return window.__backgroundCoverCssUrl || cssUrl;
+            }
             
             ${videoSetup}
 
@@ -1588,6 +1694,13 @@ export class FileDom {
 
             function applyToWindow(w) {
                 if (!isWindowAlive(w)) return;
+                try {
+                    if (window.__backgroundCoverCssUrl) {
+                        w.__backgroundCoverCssUrl = window.__backgroundCoverCssUrl;
+                    }
+                } catch (e) {
+                    // Auxiliary windows may not allow property writes during init.
+                }
                 applyStyle(w, lastCss);
                 applyVideo(w, lastVideoConfig);
             }
@@ -1671,9 +1784,10 @@ export class FileDom {
                 if (cssLoadInFlight) return;
                 cssLoadInFlight = true;
                 lastCssLoadAt = Date.now();
-                const url = withCacheBust(cssUrl);
+                const currentCssUrl = activeCssUrl();
+                const url = withCacheBust(currentCssUrl);
                 fetch(url).then(r => r.text()).then(css => {
-                    const resolvedCss = replaceRelativeTokens(css, cssBaseHref);
+                    const resolvedCss = replaceRelativeTokens(css, getCssBaseHref(currentCssUrl) || cssBaseHref);
                     lastCss = resolvedCss;
 
                     const match = resolvedCss.match(/\\/\\*background-cover-video-start\\*\\/([\\s\\S]*?)\\/\\*background-cover-video-end\\*\\//);
@@ -1720,6 +1834,10 @@ export class FileDom {
                             // ':js:' means the dynamic bundle itself changed and must be
                             // re-imported; a CSS-only change just refreshes the stylesheet
                             // so the pet/particle runtime keeps its state.
+                            const triggerMatch = target.textContent.match(/background-cover-reload-trigger:(css|js):\\d+:([0-9a-f]+)/i);
+                            if (triggerMatch && triggerMatch[2]) {
+                                window.__backgroundCoverCssUrl = cssUrlForToken(triggerMatch[2]);
+                            }
                             const wantsJsReload = target.textContent.includes('background-cover-reload-trigger:js:');
                             const bootstrap = window.__backgroundCoverBootstrap;
                             if (wantsJsReload && bootstrap && typeof bootstrap.reload === 'function') {

--- a/src/PickList.ts
+++ b/src/PickList.ts
@@ -22,6 +22,7 @@ import { FileDom } from './FileDom';
 import { ImgItem } from './ImgItem';
 import vsHelp from './vsHelp';
 import { getContext, onDidChangeGlobalState } from './global';
+import { hasCurrentImageRecord, resolveCurrentImagePath, setCurrentImagePath } from './windowBackground';
 import { BlendHelper } from './BlendHelper';
 import Color, { getColorList } from './color'; // 导入颜色定义
 import { OnlineImageHelper } from './OnlineImageHelper';
@@ -202,7 +203,7 @@ export class PickList {
     }
 
     public static needAutoUpdate(config: WorkspaceConfiguration) {
-        if (config.imagePath == '') { return; }
+        if (!resolveCurrentImagePath(config.imagePath || '')) { return; }
 
         const nowBlenaStr = BlendHelper.autoBlendModel();
         PickList.itemList = new PickList(config);
@@ -223,7 +224,7 @@ export class PickList {
 
     public static autoUpdateBlendModel() {
         const config = workspace.getConfiguration('backgroundCover');
-        if (config.imagePath == '') { return; }
+        if (!resolveCurrentImagePath(config.imagePath || '')) { return; }
 
         const context = getContext();
         const blendStr = context.globalState.get('backgroundCoverBlendModel');
@@ -269,11 +270,17 @@ export class PickList {
 
     public static async applyCurrentBackground(): Promise<boolean> {
         const config = workspace.getConfiguration('backgroundCover');
-        if (!config.get<string>('imagePath')) {
+        const resolved = resolveCurrentImagePath(config.get<string>('imagePath') || '');
+        if (!resolved && !hasCurrentImageRecord()) {
             return false;
         }
+        if (resolved) {
+            await setCurrentImagePath(resolved);
+        }
         PickList.itemList = new PickList(config);
-        const result = await PickList.itemList.updateDom(false, BlendHelper.autoBlendModel() as string);
+        const result = resolved
+            ? await PickList.itemList.updateDom(false, BlendHelper.autoBlendModel() as string)
+            : await PickList.itemList.updateDom(true);
         PickList.itemList = undefined;
         return result;
     }
@@ -386,7 +393,7 @@ export class PickList {
 
     public constructor(config: WorkspaceConfiguration, pickList?: QuickPick<ImgItem>) {
         this.config = config;
-        this.imgPath = config.imagePath;
+        this.imgPath = resolveCurrentImagePath(config.imagePath || '');
         this.opacity = config.opacity;
         this.sizeModel = config.sizeModel || 'cover';
         this.imageFileType = 0;
@@ -797,7 +804,7 @@ export class PickList {
                 }
 
                 // Current image (so we can mark it with a check)
-                const currentImg = (this.config.get<string>('imagePath') || '').toLowerCase();
+                const currentImg = (resolveCurrentImagePath(this.config.get<string>('imagePath') || '') || '').toLowerCase();
                 const normalize = (p: string) => p.replace(/\\/g, '/').toLowerCase();
 
                 // Most-recently-used list (kept in globalState, capped at 5)
@@ -1266,7 +1273,7 @@ export class PickList {
         persist: boolean = true,
         options: UpdateBackgroundOptions = {}
     ) {
-        if (!path) { path = this.config.get<string>('imagePath'); }
+        if (!path) { path = resolveCurrentImagePath(this.config.get<string>('imagePath') || ''); }
         if (!path) { return vsHelp.showInfo('Unfetched Picture Path / 未获取到图片路径'); }
 
         // Large local-file pre-check: warn user before applying anything > 5MB so
@@ -1342,11 +1349,15 @@ export class PickList {
     }
 
     private async setConfigValue(name: string, value: any, updateDom: Boolean = true, persist: boolean = true) {
-        if (persist) {
-            await this.config.update(name, value, ConfigurationTarget.Global);
-            this.config = workspace.getConfiguration('backgroundCover');
-        }
         if (name === 'imagePath') {
+            await setCurrentImagePath(typeof value === 'string' ? value : '');
+            if (persist && typeof value === 'string' && value) {
+                const globalPath = this.config.get<string>('imagePath') || '';
+                if (!globalPath) {
+                    await this.config.update(name, value, ConfigurationTarget.Global);
+                    this.config = workspace.getConfiguration('backgroundCover');
+                }
+            }
             const context = getContext();
             const hasOnlineFolder = context.globalState.get('backgroundCoverOnlineFolder');
             if (typeof value === 'string' && value && this.isOnlineUrl(value) && !hasOnlineFolder) {
@@ -1354,10 +1365,16 @@ export class PickList {
             } else {
                 context.globalState.update('backgroundCoverSingleImageSource', undefined);
             }
+            this.imgPath = value;
+            if (updateDom) { await this.updateDom(); }
+            return true;
+        }
+        if (persist) {
+            await this.config.update(name, value, ConfigurationTarget.Global);
+            this.config = workspace.getConfiguration('backgroundCover');
         }
         switch (name) {
             case 'opacity': this.opacity = value; break;
-            case 'imagePath': this.imgPath = value; break;
             case 'sizeModel': this.sizeModel = value; break;
             case 'blur': this.blur = value; break;
             default: break;
@@ -1419,7 +1436,8 @@ export class PickList {
 
         try {
             if (uninstall) {
-                this.config.update("imagePath", "", ConfigurationTarget.Global);
+                await setCurrentImagePath('');
+                this.imgPath = '';
                 result = await dom.clearBackground();
             } else {
                 result = await dom.install();
@@ -1435,23 +1453,23 @@ export class PickList {
                     if (this.quickPick) {
                         this.quickPick.hide();
                     }
-                    if (!dom.didUpdateCss && !dom.didUpdateDynamicJs) {
-                        window.setStatusBarMessage('Background already up to date. / 背景已是最新。', 3000);
-                        return false;
-                    }
+                    const didChangeAssets = uninstall || dom.didUpdateCss || dom.didUpdateDynamicJs;
                     // Unique trigger per call so the MutationObserver in the
                     // injected loader always detects a DOM change (VSCode may
                     // skip mutation events if the text is identical). The kind
                     // segment tells the loader whether it must re-import the
                     // dynamic JS or can simply refresh the CSS in place.
+                    // The session hash binds this window's loader to its own CSS file.
                     PickList._reloadTriggerSeq += 1;
                     const triggerKind = dom.didUpdateDynamicJs ? 'js' : 'css';
-                    const triggerText = `background-cover-reload-trigger:${triggerKind}:${PickList._reloadTriggerSeq}`;
+                    const triggerText = `background-cover-reload-trigger:${triggerKind}:${PickList._reloadTriggerSeq}:${dom.windowCssToken}`;
                     const triggerMsg = window.setStatusBarMessage(triggerText);
 
                     setTimeout(() => {
                         triggerMsg.dispose();
-                        window.setStatusBarMessage('Background updated successfully! / 背景更新成功！', 5000);
+                        if (didChangeAssets) {
+                            window.setStatusBarMessage('Background updated successfully! / 背景更新成功！', 5000);
+                        }
                     }, 1000);
 
                     return false;

--- a/src/StudioViewProvider.ts
+++ b/src/StudioViewProvider.ts
@@ -17,6 +17,7 @@ import {
 import { PickList, getAllPets } from './PickList';
 import { onDidChangeGlobalState } from './global';
 import { getColorEntries } from './color';
+import { resolveCurrentImagePath } from './windowBackground';
 
 /**
  * Vue-powered single-pane configuration webview.
@@ -86,7 +87,7 @@ export class StudioViewProvider implements WebviewViewProvider {
         const cfg = workspace.getConfiguration('backgroundCover');
         const gs = this.ctx.globalState;
 
-        const imagePath = cfg.get<string>('imagePath') || '';
+        const imagePath = resolveCurrentImagePath(cfg.get<string>('imagePath') || '');
         const imagePathDisplay = this.toWebviewUri(imagePath);
 
         const recentRaw = gs.get<string[]>('backgroundCoverRecentImages', []) || [];

--- a/src/SudoPromptHelper.ts
+++ b/src/SudoPromptHelper.ts
@@ -7,11 +7,14 @@ export class SudoPromptHelper {
             sudo.exec(command, options, (error, stdout, stderr) => {
                 if (error) {
                     reject(error);
-                } else if (stderr) {
-                    reject(new Error(stderr ? stderr.toString() : ''));
-                } else {
-                    resolve(stdout ? stdout.toString() : '');
+                    return;
                 }
+                // icacls/takeown often write status text to stderr even when they
+                // succeed. Treat a zero exit as success and keep stderr for logs.
+                if (stderr) {
+                    console.warn('[SudoPromptHelper] stderr:', stderr.toString());
+                }
+                resolve(stdout ? stdout.toString() : '');
             });
         });
     }

--- a/src/backgroundCoverView.ts
+++ b/src/backgroundCoverView.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ActionType, PickList } from './PickList';
 import { getContext, onDidChangeGlobalState } from './global';
+import { resolveCurrentImagePath } from './windowBackground';
 
 // Localization
 const messages = {
@@ -261,7 +262,7 @@ export class BackgroundCoverViewProvider implements vscode.TreeDataProvider<Conf
         const onlineFolder = context?.globalState.get<string>('backgroundCoverOnlineFolder');
 
         if (element.label === t('imageSource')) {
-            const currentPath = config.get<string>('imagePath') || t('none');
+            const currentPath = resolveCurrentImagePath(config.get<string>('imagePath') || '') || t('none');
             const displayPath = currentPath.length > 30 ? '...' + currentPath.substr(-30) : currentPath;
             
             items.push(new ConfigItem(t('currentImage'), vscode.TreeItemCollapsibleState.None, 'value', undefined, undefined, undefined, displayPath, 'file'));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,9 +22,10 @@ import { PickList } from './PickList';
 import vsHelp from './vsHelp';
 import ReaderViewProvider from './readerView';
 import { setContext } from './global';
-import { CUSTOM_CSS_FILE_PATH } from './FileDom';
+import { CUSTOM_JS_FILE_PATH } from './FileDom';
 import { BackgroundCoverViewProvider } from './backgroundCoverView';
 import { StudioViewProvider } from './StudioViewProvider';
+import { hasCurrentImageRecord, resolveCurrentImagePath, setCurrentImagePath } from './windowBackground';
 
 
 export function activate(context: ExtensionContext) {
@@ -46,10 +47,12 @@ export function activate(context: ExtensionContext) {
 	context.subscriptions.push(particleBtn);
 
 	// 异步检查 VSCode 版本变化，不阻塞启动
-	checkVSCodeVersionChanged(context).then(isChanged => {
+	checkVSCodeVersionChanged(context).then(async isChanged => {
 		if (!isChanged) {
 			const config = workspace.getConfiguration('backgroundCover');
-			if (config.imagePath && !fs.existsSync(CUSTOM_CSS_FILE_PATH)) {
+			const resolved = resolveCurrentImagePath(config.imagePath || '');
+			const hasImage = !!resolved || hasCurrentImageRecord();
+			if (hasImage && !fs.existsSync(CUSTOM_JS_FILE_PATH)) {
 				const ex: Extension<any> | undefined = extensions.getExtension('manasxx.background-cover');
 				const extensionVersion: string = ex ? ex.packageJSON['version'] : '';
 				window.showInformationMessage(
@@ -65,7 +68,9 @@ export function activate(context: ExtensionContext) {
 					}
 				});
 			} else {
-				// 防止同时运行
+				if (hasImage) {
+					await PickList.applyCurrentBackground();
+				}
 				PickList.autoUpdateBackground();
 			}
 		}
@@ -149,9 +154,18 @@ export function activate(context: ExtensionContext) {
 
 
 	context.subscriptions.push(commands.registerCommand('backgroundCover.setConfig', async (key: string, value: any) => {
+		if (key === 'backgroundCover.imagePath') {
+			await setCurrentImagePath(typeof value === 'string' ? value : '');
+			const bgConfig = workspace.getConfiguration('backgroundCover');
+			const globalPath = bgConfig.get<string>('imagePath') || '';
+			if (!globalPath && typeof value === 'string' && value) {
+				await workspace.getConfiguration().update(key, value, true);
+			}
+			await PickList.applyCurrentBackground();
+			return;
+		}
 		const config = workspace.getConfiguration();
 		await config.update(key, value, true);
-		// Trigger update
 		const newConfig = workspace.getConfiguration('backgroundCover');
 		PickList.needAutoUpdate(newConfig);
 	}));
@@ -187,8 +201,8 @@ export function activate(context: ExtensionContext) {
 async function checkVSCodeVersionChanged(context: ExtensionContext): Promise<boolean> {
 	// 获取配置
 	let config = workspace.getConfiguration('backgroundCover');
-	// 如果没有设置背景图，则不处理
-	if (!config.imagePath) {
+	const resolved = resolveCurrentImagePath(config.imagePath || '');
+	if (!resolved && !hasCurrentImageRecord()) {
 		return false;
 	}
 

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -41,7 +41,30 @@ function main(): boolean {
             allOk = false;
         }
     }
+    removeBackgroundCoverCssFiles(path.join(base, 'resources', 'app', 'out', 'vs', 'workbench'));
+    removeBackgroundCoverCssFiles(path.join(base, 'resources', 'app', 'out', 'vs', 'code', 'browser', 'workbench'));
     return allOk;
+}
+
+function removeBackgroundCoverCssFiles(dir: string): void {
+    if (!fs.existsSync(dir)) {
+        return;
+    }
+    let names: string[] = [];
+    try {
+        names = fs.readdirSync(dir);
+    } catch {
+        return;
+    }
+    for (const name of names) {
+        if (name.startsWith('css-background-cover') && name.endsWith('.css')) {
+            try {
+                fs.unlinkSync(path.join(dir, name));
+            } catch {
+                // Best-effort: uninstall runs without vscode APIs or sudo prompts.
+            }
+        }
+    }
 }
 
 function clearCssContent(content: string): string {

--- a/src/windowBackground.ts
+++ b/src/windowBackground.ts
@@ -1,0 +1,77 @@
+import * as crypto from 'crypto';
+import * as path from 'path';
+import { env, workspace } from 'vscode';
+import { getContext, onDidChangeGlobalState } from './global';
+
+const WINDOW_IMAGES_KEY = 'backgroundCover.windowImages';
+const WORKSPACE_IMAGES_KEY = 'backgroundCover.workspaceImages';
+
+function shortHash(input: string): string {
+    return crypto.createHash('md5').update(input).digest('hex').slice(0, 8);
+}
+
+export function getSessionHash(): string {
+    return shortHash(env.sessionId || 'default-session');
+}
+
+export function getWorkspaceKey(): string | undefined {
+    const folder = workspace.workspaceFolders && workspace.workspaceFolders[0];
+    if (!folder) {
+        return undefined;
+    }
+    const normalized = path.normalize(folder.uri.fsPath).replace(/\\+/g, '/').replace(/\/+$/, '').toLowerCase();
+    return shortHash(normalized);
+}
+
+export function getWindowCssFileName(): string {
+    return `css-background-cover.${getSessionHash()}.css`;
+}
+
+function readImageMap(key: string): Record<string, string> {
+    return { ...(getContext().globalState.get<Record<string, string>>(key, {}) || {}) };
+}
+
+export function hasCurrentImageRecord(): boolean {
+    const windowMap = readImageMap(WINDOW_IMAGES_KEY);
+    if (Object.prototype.hasOwnProperty.call(windowMap, getSessionHash())) {
+        return true;
+    }
+    const workspaceKey = getWorkspaceKey();
+    if (!workspaceKey) {
+        return false;
+    }
+    const workspaceMap = readImageMap(WORKSPACE_IMAGES_KEY);
+    return Object.prototype.hasOwnProperty.call(workspaceMap, workspaceKey);
+}
+
+export function resolveCurrentImagePath(globalFallback?: string): string {
+    const windowMap = readImageMap(WINDOW_IMAGES_KEY);
+    const sessionHash = getSessionHash();
+    if (Object.prototype.hasOwnProperty.call(windowMap, sessionHash)) {
+        return windowMap[sessionHash] || '';
+    }
+    const workspaceKey = getWorkspaceKey();
+    if (workspaceKey) {
+        const workspaceMap = readImageMap(WORKSPACE_IMAGES_KEY);
+        if (Object.prototype.hasOwnProperty.call(workspaceMap, workspaceKey)) {
+            return workspaceMap[workspaceKey] || '';
+        }
+    }
+    return globalFallback || '';
+}
+
+export async function setCurrentImagePath(imagePath: string): Promise<void> {
+    const context = getContext();
+    const sessionHash = getSessionHash();
+    const windowMap = readImageMap(WINDOW_IMAGES_KEY);
+    windowMap[sessionHash] = imagePath || '';
+    await context.globalState.update(WINDOW_IMAGES_KEY, windowMap);
+
+    const workspaceKey = getWorkspaceKey();
+    if (workspaceKey) {
+        const workspaceMap = readImageMap(WORKSPACE_IMAGES_KEY);
+        workspaceMap[workspaceKey] = imagePath || '';
+        await context.globalState.update(WORKSPACE_IMAGES_KEY, workspaceMap);
+    }
+    onDidChangeGlobalState.fire();
+}


### PR DESCRIPTION
## Summary
- 两个主窗口可以各挂一张图：换图只写当前窗口的 CSS（`css-background-cover.<sessionHash>.css`）和窗口/工作区状态，不再把全局 `imagePath` 当直播通道。
- 界面脚本握手后记住本窗口的 CSS 地址，焦点回来不会再去读那份共享文件；共享 `css-background-cover.css` 只作新窗口尚未握手时的兜底。
- 关掉再开同一个项目，按工作区记住上次的图；新窗口没有记录时仍用全局默认图。同一窗口里的 Agent Window / Glass 继续跟随主窗口。
- 卸载和清背景会扫掉 `css-background-cover*.css`，不会只删旧的那一个文件名。
- 写入失败时对 workbench 目录一次性授权（新文件继承写入权限），避免每个新窗口都对单文件弹多次管理员确认。

## Test plan
- [x] 两个不同项目窗口：A 换图，B 的背景和 Studio 当前图不变。
- [x] A 开自动换图，B 不跟着换。
- [x] B 重新点回自己的窗口，不会变成 A 的图。
- [x] 新开第三个窗口：用默认图，不是 A 刚换的那张。
- [x] 关掉再打开同一个项目：恢复该项目上次的图。
- [x] 同一窗口的 Agent Window：仍跟主窗口。
- [x] 清背景 / 卸载：窗口 CSS 文件被清掉。
- [x] 装上后完全退出再打开 VS Code / Cursor（软重载不够），新加载器才会生效。
- [x] 第一次授权后，再开新窗口不应再连弹多次 UAC。